### PR TITLE
docs: clarify reporting/observability improvement opportunities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,54 @@
 # desafio-itau-backend
 
+## API de Transações + Estatísticas (Java 21 + Spring Boot)
+
+Implementação do desafio do Itaú com foco em **clareza de código**, **regras de negócio explícitas** e **resposta rápida em memória** (sem banco/cache externo).
+
+### O que este projeto entrega
+
+- `POST /transacao` com validação de payload, valor e data/hora
+- `DELETE /transacao` para limpar estado em memória
+- `GET /estatistica` com janela móvel dos últimos 60 segundos (`count`, `sum`, `avg`, `min`, `max`)
+- Contratos HTTP aderentes ao enunciado (`201`, `200`, `422`, `400`)
+
+### Stack
+
+- Java 21
+- Spring Boot 3.x
+- Maven
+
+### Como executar localmente
+
+```bash
+./mvnw spring-boot:run
+```
+
+Servidor padrão: `http://localhost:8080`
+
+### Exemplos rápidos
+
+Criar transação:
+
+```bash
+curl -i -X POST http://localhost:8080/transacao \
+  -H "Content-Type: application/json" \
+  -d '{"valor":123.45,"dataHora":"2026-03-14T14:20:00.000Z"}'
+```
+
+Buscar estatísticas:
+
+```bash
+curl -s http://localhost:8080/estatistica
+```
+
+Limpar transações:
+
+```bash
+curl -i -X DELETE http://localhost:8080/transacao
+```
+
+---
+
 # Itaú Unibanco - Desafio de Programação
 
 Este é um desafio bacana tanto de desenvolvimento de software quanto de engenharia de software. Queremos testar sua capacidade de construir um software com várias partes diferentes funcionando em conjunto!

--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Como resposta, espera-se que este endpoint responda com:
 
 Vamos propôr a seguir alguns desafios extras caso você queira testar seus conhecimentos ao máximo! Nenhum desses requisitos é obrigatório, mas são desejados e podem ser um diferencial!
 
+## 5. Oportunidades de melhoria para _reporting_ e acompanhamento
+
+Como este desafio costuma ser usado em entrevistas e também como base de estudo, vale deixar explícitas algumas oportunidades de melhoria para facilitar a evolução do projeto no dia a dia:
+
+- **Métricas de negócio do endpoint de estatística:** além do payload retornado (`count`, `sum`, `avg`, `min`, `max`), registrar métricas agregadas para acompanhar comportamento ao longo do tempo (picos de volume, janelas sem transação, variação de média).
+- **Métricas técnicas por endpoint:** latência p50/p95/p99, taxa de erro (4xx/5xx) e throughput por rota (`POST /transacao`, `DELETE /transacao`, `GET /estatistica`).
+- **Correlação de requisições:** adicionar um identificador de correlação em logs facilita investigação de incidentes e análise de fluxos entre chamadas.
+- **Sinais de qualidade de dados:** monitorar taxa de rejeição de transações inválidas (ex.: valor negativo, data futura, payload malformado) ajuda a detectar problemas de integração no cliente.
+- **Documentação de indicadores operacionais:** manter uma seção no README com os principais indicadores e seus significados acelera onboarding e torna o projeto mais amigável para quem está avaliando.
+
+> Sugestão prática: com Spring Boot, é possível começar por Actuator + Micrometer e exportar métricas para Prometheus/Grafana.
+
 1. **Testes automatizados:** Sejam unitários e/ou funcionais, testes automatizados são importantes e ajudam a evitar problemas no futuro. Se você fizer testes automatizados, atente-se na efetividade dos seus testes! Por exemplo, testar apenas os "caminhos felizes" não é muito efetivo.
 2. **Containerização:** Você consegue criar meios para disponibilizar sua aplicação como um container? _OBS: Não é necessário publicar o container da sua aplicação!_
 3. **Logs:** Sua aplicação informa o que está acontecendo enquanto ela trabalha? Isso é útil para ajudar as pessoas desenvolvedoras a solucionar eventuais problemas que possam ocorrer.


### PR DESCRIPTION
## What this PR does

This PR improves the README by adding a new section focused on **reporting and observability improvement opportunities** for the challenge project.

It documents practical ideas such as:
- business-level reporting signals for `/estatistica` behavior
- technical metrics (latency/error/throughput) by endpoint
- request correlation for incident analysis
- monitoring invalid transaction rejection rates
- documenting operational indicators for easier onboarding

It also includes a practical suggestion to start with **Spring Boot Actuator + Micrometer** and export metrics to Prometheus/Grafana.

## Why this is useful

The original challenge is excellent for implementation practice, but candidates and reviewers often also benefit from guidance on how to evolve the API in production-like scenarios.

This addition aims to help contributors understand not only **what to build**, but also **how to operate and improve** it over time, especially around visibility and reporting.

## Scope

- Documentation-only change (`README.md`)
- No behavioral/code changes

Thanks for maintaining this project 🙌
